### PR TITLE
Change compile keyword to implementation for Gradle 7+

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -5,7 +5,7 @@ repositories{
 }
 
 dependencies {
-    compile(name:'barcodescanner-release-2.1.5', ext:'aar')
+    implementation(name:'barcodescanner-release-2.1.5', ext:'aar')
 }
 
 android {


### PR DESCRIPTION
With the upgrade to [cordova-android 11](https://cordova.apache.org/announcements/2022/07/12/cordova-android-release-11.0.0.html) the Android builds are now done with Gradle 7.4.2. Gradle removed the `compile` keyword with version 7.x. As [described by Gradle](https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal), the keyword is to be replaced by `implementation`.